### PR TITLE
add kustomize example

### DIFF
--- a/kustomize/overlays-example/base/deploymentconfig.yaml
+++ b/kustomize/overlays-example/base/deploymentconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overlays-example
+spec:
+  replicas: 2
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: overlays-example
+  template:
+    metadata:
+      labels:
+        app: overlays-example
+    spec:
+      containers:
+      - image: quay.io/acend/example-web-go
+        name: overlays-example
+        ports:
+        - containerPort: 5000

--- a/kustomize/overlays-example/base/kustomization.yaml
+++ b/kustomize/overlays-example/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: overlays-example
+  app.kubernetes.io/managed-by: kustomize
+
+resources:
+- deploymentconfig.yaml
+- service.yaml
+
+
+generatorOptions:
+  # commonLabels will not be respected by generator
+  labels:
+    app: overlays-example
+    app.kubernetes.io/managed-by: kustomize

--- a/kustomize/overlays-example/base/service.yaml
+++ b/kustomize/overlays-example/base/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app: overlays-example
+    appStageTag: development
+  name: overlays-example
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    deploymentconfig: overlays-example
+  sessionAffinity: None
+  type: ClusterIP

--- a/kustomize/overlays-example/overlays/production/deploymentconfig.yaml
+++ b/kustomize/overlays-example/overlays/production/deploymentconfig.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: overlays-example
+spec:
+  replicas: 4

--- a/kustomize/overlays-example/overlays/production/kustomization.yaml
+++ b/kustomize/overlays-example/overlays/production/kustomization.yaml
@@ -1,0 +1,20 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+bases:
+- ../../base
+
+commonLabels:
+  appStageTag: production
+
+generatorOptions:
+  # commonLabels will not be respected by generator
+  labels:
+    app: overlays-example
+    app.kubernetes.io/managed-by: kustomize
+    appStageTag: production
+
+
+patchesStrategicMerge:
+- deploymentconfig.yaml
+# - service.yaml

--- a/kustomize/simple-example/deploymentconfig.yaml
+++ b/kustomize/simple-example/deploymentconfig.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: simple-example
+spec:
+  replicas: 2
+  revisionHistoryLimit: 3
+  selector:
+    matchLabels:
+      app: simple-example
+  template:
+    metadata:
+      labels:
+        app: simple-example
+    spec:
+      containers:
+      - image: quay.io/acend/example-web-go
+        name: simple-example
+        ports:
+        - containerPort: 5000

--- a/kustomize/simple-example/kustomization.yaml
+++ b/kustomize/simple-example/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app: simple-example
+  app.kubernetes.io/managed-by: kustomize
+
+resources:
+- deploymentconfig.yaml
+- service.yaml
+
+
+generatorOptions:
+  # commonLabels will not be respected by generator
+  labels:
+    app: simple-example
+    app.kubernetes.io/managed-by: kustomize

--- a/kustomize/simple-example/service.yaml
+++ b/kustomize/simple-example/service.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  labels:
+    app: simple-example
+    appStageTag: development
+  name: simple-example
+spec:
+  ports:
+  - name: 8080-tcp
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    deploymentconfig: simple-example
+  sessionAffinity: None
+  type: ClusterIP


### PR DESCRIPTION
Contains two examples. One for a simple-app with only top-level kustomize-files. Second one with a base/overlays-example.

```
# simple-example
argocd app create argo-kustomize-$LAB_USER --repo $REPO --path 'kustomize/simple-example' --dest-server https://kubernetes.default.svc --dest-namespace $LAB_USER

# overlays-example
argocd app create argo-kustomize-$LAB_USER --repo $REPO --path 'kustomize/overlays-example/overlays/production' --dest-server https://kubernetes.default.svc --dest-namespace $LAB_USER
```